### PR TITLE
Updated travis files. XMP is now disabled on Travis since Travis uses…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: c
 compiler:
   - gcc
-  - clang
 # These fail because ioquake3 is missing vorbis
 # Re-enable after they add vorbis or OA imports it
 #  - i686-w64-mingw32-gcc
@@ -12,7 +11,7 @@ script: ./travis-ci-build.sh
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get remove -qq -y mingw32
-  - sudo apt-get install -q -y libgl1-mesa-dev libsdl1.2-dev libvorbis-dev libfreetype6-dev mingw-w64 libxmp-dev
+  - sudo apt-get install -q -y libgl1-mesa-dev libsdl1.2-dev libvorbis-dev libfreetype6-dev mingw-w64
 
 notifications:
   email: false

--- a/travis-ci-build.sh
+++ b/travis-ci-build.sh
@@ -2,6 +2,8 @@
 
 failed=0;
 
+# Travis is currently running 12.04 and do not support XMP
+
 # check if testing mingw
 if [ "$CC" = "i686-w64-mingw32-gcc" ]; then
 	export PLATFORM=mingw32
@@ -18,11 +20,11 @@ else
 fi
 
 # Default Build
-(make clean release) || failed=1;
+(make clean release USE_CODEC_XMP=0) || failed=1;
 
 # Test additional options
 if [ $haveExternalLibs -eq 1 ]; then
-	(make clean release USE_CODEC_VORBIS=1 USE_FREETYPE=1) || failed=1;
+	(make clean release USE_CODEC_XMP=0 USE_CODEC_VORBIS=1 USE_FREETYPE=1) || failed=1;
 fi
 
 if [ $failed -eq 1 ]; then


### PR DESCRIPTION
Updated Travis files to work on Ubuntu 12.04. Also clang is currently disabled and will be so until: 92b74e58cc29410ad2e2e814bda9861aa32789f8 is included