### PR TITLE
The engine is now compileable with a MXE environment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2648,7 +2648,7 @@ $(B)/client/%.o: $(ASMDIR)/%.s
 
 # k8 so inline assembler knows about SSE
 $(B)/client/%.o: $(ASMDIR)/%.c
-	$(DO_CC) -march=k8
+	$(DO_CC) -march=k8 -mmmx -msse2
 
 $(B)/client/%.o: $(CDIR)/%.c
 	$(DO_CC)
@@ -2753,7 +2753,7 @@ $(B)/ded/%.o: $(ASMDIR)/%.s
 
 # k8 so inline assembler knows about SSE
 $(B)/ded/%.o: $(ASMDIR)/%.c
-	$(DO_CC) -march=k8
+	$(DO_CC) -march=k8 -mmmx -msse2
 
 $(B)/ded/%.o: $(SDIR)/%.c
 	$(DO_DED_CC)

--- a/Makefile.OpenArena
+++ b/Makefile.OpenArena
@@ -20,14 +20,18 @@ VERSION=3.0.0a
 USE_CODEC_VORBIS=1
 USE_CODEC_OPUS=0
 
+ifndef USE_CODEC_XMP
 USE_CODEC_XMP=1
+endif
 
 # FLTO Test
 
 OPTIMIZE += -flto
 
 # Can't use CURL on my system atm
+ifndef USE_CURL
 USE_CURL=0
+endif
 
 # This doesn't work with OpenArena yet
 BUILD_RENDERER_OPENGL2=0


### PR DESCRIPTION
The "-march=k8" parameter is not recognized (it is just ignored). I have explicitly added "-mmmx -msse2" in these cases. This does not cause problems with the "i686-w64-mingw32-gcc" that are provided in Ubuntu. 

Windows version can be compiled with: PLATFORM=mingw32 ARCH=x86 CC=i686-w64-mingw32.static-gcc WINDRES=i686-w64-mingw32.static-windres LD=i686-w64-mingw32.static-ld make USE_CODEC_XMP=0 USE_CURL=1

XMP can be enabled if you have compiled the libxmp. I have that in an image that I'll use for builds.