### PR TITLE
Xdg home

### DIFF
--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -32,6 +32,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
   #define CLIENT_WINDOW_TITLE     	"OpenArena"
   #define CLIENT_WINDOW_MIN_TITLE 	"OA"
   #define HOMEPATH_NAME_UNIX		".openarena"
+  #define HOMEPATH_NAME_XDG         "openarena"
   #define HOMEPATH_NAME_WIN		"OpenArena"
   #define HOMEPATH_NAME_MACOSX		HOMEPATH_NAME_WIN
   #define GAMENAME_FOR_MASTER		"Quake3Arena"	// must NOT contain whitespace.  No servers show up if you use "openarena"

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -27,16 +27,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // A user mod should never modify this file
 
 #ifdef STANDALONE
-  #define PRODUCT_NAME			"ioq3+oa"
-  #define BASEGAME			"baseoa"
-  #define CLIENT_WINDOW_TITLE     	"OpenArena"
-  #define CLIENT_WINDOW_MIN_TITLE 	"OA"
-  #define HOMEPATH_NAME_UNIX		".openarena"
-  #define HOMEPATH_NAME_XDG         "openarena"
-  #define HOMEPATH_NAME_WIN		"OpenArena"
-  #define HOMEPATH_NAME_MACOSX		HOMEPATH_NAME_WIN
-  #define GAMENAME_FOR_MASTER		"Quake3Arena"	// must NOT contain whitespace.  No servers show up if you use "openarena"
-  #define LEGACY_PROTOCOL		1 // OA still uses the legacy protocol
+  #define PRODUCT_NAME              "ioq3+oa"
+  #define BASEGAME                  "baseoa"
+  #define CLIENT_WINDOW_TITLE       "OpenArena"
+  #define CLIENT_WINDOW_MIN_TITLE   "OA"
+  #define HOMEPATH_NAME_UNIX        ".openarena"
+  #define HOMEPATH_NAME_WIN         "OpenArena"
+  #define HOMEPATH_NAME_MACOSX      HOMEPATH_NAME_WIN
+  #define HOMEPATH_NAME_XDG         HOMEPATH_NAME_WIN
+  #define GAMENAME_FOR_MASTER       "Quake3Arena"	// must NOT contain whitespace.  No servers show up if you use "openarena"
+  #define LEGACY_PROTOCOL           1 // OA still uses the legacy protocol
 #else
   #define PRODUCT_NAME			"ioq3"
   #define BASEGAME			"baseq3"

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -1110,7 +1110,7 @@ char    *Sys_DefaultAppPath(void);
 #endif
 
 void  Sys_SetDefaultHomePath(const char *path);
-char	*Sys_DefaultHomePath(void);
+const char *Sys_DefaultHomePath(void);
 const char *Sys_Dirname( char *path );
 const char *Sys_Basename( char *path );
 char *Sys_ConsoleInput(void);

--- a/code/sys/sys_unix.c
+++ b/code/sys/sys_unix.c
@@ -68,6 +68,7 @@ static void Sys_ConcatXdgHomepathName(char* dest, size_t n) {
 /**
  * Assignes a buffer with the value of the Xdg home.
  * Normally: "$HOME/.local/share/openarena"
+ * XDG_DATA_HOME will also be recursivly created if it is missing
  * If it failes the destination buffer will be the empty string.
  * @param dest Buffer to place the value into
  * @param n Size of buffer
@@ -77,12 +78,14 @@ static void Sys_SetXdgDataHomePath(char* dest, size_t n) {
 	dest[0] = '\0';
 	if (xdgDataPath) {
 		Com_sprintf(dest, n, "%s/", xdgDataPath);
+		FS_CreatePath(dest);
 		Sys_ConcatXdgHomepathName(dest, n);
 		return;
 	}
 	const char* homeFolder = getHome();
 	if (homeFolder) {
 		Com_sprintf(dest, n, "%s/.local/share/", homeFolder);
+		FS_CreatePath(dest);
 		Sys_ConcatXdgHomepathName(dest, n);
 	}
 }

--- a/code/sys/sys_unix.c
+++ b/code/sys/sys_unix.c
@@ -150,7 +150,7 @@ static void CreateXDGPathAndMisc( void ) {
 			Com_Printf("Failed to move \"%s\" to \"%s\". Error code: %d. Non fatal.", homeClassic, homeXdg, errCode);
 		}
 	}
-	if (Sys_IsDir(homeXdg)) {
+	if (!Sys_IsDir(homeXdg)) {
 		int errCode = Sys_Mkdir(homeXdg);
 		if (errCode) {
 			Com_Printf("Failed to create \"%s\". Error code: %d. This is quite bad.", homeXdg, errCode);

--- a/code/sys/sys_unix.c
+++ b/code/sys/sys_unix.c
@@ -107,7 +107,7 @@ static void Sys_SetHomePaths( void ) {
  */
 static qboolean Sys_IsSymbolic(const char* path) {
 	struct stat buf;
-    int errCode = lstat(path, &buf);
+	int errCode = lstat(path, &buf);
 	return (errCode == 0);
 }
 

--- a/code/sys/sys_unix.c
+++ b/code/sys/sys_unix.c
@@ -150,6 +150,14 @@ static void CreateXDGPathAndMisc( void ) {
 			Com_Printf("Failed to move \"%s\" to \"%s\". Error code: %d. Non fatal.", homeClassic, homeXdg, errCode);
 		}
 	}
+	if (!Sys_IsDir(homeXdg) && Sys_IsDir(homeClassic)) {
+		//Home classic does still exist and home Xdg does not. This means that the rename above must have failed.
+		//Link it istead
+		int errCode = symlink(homeClassic, homeXdg);
+		if (errCode) {
+			Com_Printf("Failed to create symbolic link \"%s\". Error code: %d. This is quite bad.", homeXdg, errCode);
+		}
+	}
 	if (!Sys_IsDir(homeXdg)) {
 		int errCode = Sys_Mkdir(homeXdg);
 		if (errCode) {
@@ -160,12 +168,6 @@ static void CreateXDGPathAndMisc( void ) {
 		int errCode = symlink(homeXdg, homeClassic);
 		if (errCode) {
 			Com_Printf("Failed to create symbolic link \"%s\". Error code: %d. This is quite bad.", homeClassic, errCode);
-		}
-	}
-	if (!Sys_IsDir(homeXdg) && Sys_IsDir(homeClassic)) {
-		int errCode = symlink(homeClassic, homeXdg);
-		if (errCode) {
-			Com_Printf("Failed to create symbolic link \"%s\". Error code: %d. This is quite bad.", homeXdg, errCode);
 		}
 	}
 }
@@ -193,12 +195,6 @@ const char *Sys_DefaultHomePath(void)
 			else
 				Q_strcat(homePath, sizeof(homePath), HOMEPATH_NAME_MACOSX);
 #else
-#if 0
-			if(com_homepath->string[0])
-				Q_strcat(homePath, sizeof(homePath), com_homepath->string);
-			else
-				Q_strcat(homePath, sizeof(homePath), HOMEPATH_NAME_UNIX);
-#endif
 			CreateXDGPathAndMisc();
 			Com_sprintf(homePath, sizeof(homePath), "%s", homeXdg);
 #endif

--- a/code/sys/sys_win32.c
+++ b/code/sys/sys_win32.c
@@ -92,7 +92,7 @@ void Sys_SetFloatEnv(void)
 Sys_DefaultHomePath
 ================
 */
-char *Sys_DefaultHomePath( void )
+const char *Sys_DefaultHomePath( void )
 {
 	TCHAR szPath[MAX_PATH];
 	FARPROC qSHGetFolderPath;


### PR DESCRIPTION
Uses XDG folder structure as described on Issue #30 

Symlinks are used to make sure that references to ~/.openarena will still work for some time.
Creation of these symlinks will be removed from "next major version"+1.

If no further objections I'll merge this in 24 hours.