### PR TITLE
Changed widescreen FOV formula to Hor+

### DIFF
--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -196,6 +196,12 @@ typedef int		sfxHandle_t;
 typedef int		fileHandle_t;
 typedef int		clipHandle_t;
 
+// convert angle from radians to degrees
+#define DEGREES( a ) ((a) * 180.0 / M_PI)
+ 
+// convert angle from degrees to radians
+#define RADIANS( a ) ((a) / 180.0 * M_PI)
+
 #define PAD(base, alignment)	(((base)+(alignment)-1) & ~((alignment)-1))
 #define PADLEN(base, alignment)	(PAD((base), (alignment)) - (base))
 

--- a/code/renderer_oa/tr_scene.c
+++ b/code/renderer_oa/tr_scene.c
@@ -413,14 +413,21 @@ void RE_RenderScene( const refdef_t *fd ) {
 	parms.viewportHeight = tr.refdef.height;
 	parms.isPortal = qfalse;
 
-	// In Vert- FOV the horizontal FOV is unchanged, so we use it to
-	// calculate the vertical FOV that would be used if playing on 4:3 to
-	// get the Hor+ vertical FOV.
-	parms.fovY = RE_HfovToVfov( tr.refdef.fov_x, 4.0 / 3.0 );
+	if (fd->rdflags & RDF_NOWORLDMODEL) { // in menu
+		// Here we don't adjust the FOV
+		parms.fovX = tr.refdef.fov_x;
+		parms.fovY = tr.refdef.fov_y;
+	} else {
+		// In Vert- FOV the horizontal FOV is unchanged, so we use it to
+		// calculate the vertical FOV that would be used if playing on
+		// 4:3 to get the Hor+ vertical FOV
+		parms.fovY = RE_HfovToVfov( tr.refdef.fov_x, 4.0 / 3.0 );
 
-	// Then we use the Hor+ vertical FOV to calculate our new expanded
-	// horizontal FOV
-	parms.fovX = RE_VfovToHfov( parms.fovY, (float)tr.refdef.width / tr.refdef.height  );
+		// Then we use the Hor+ vertical FOV to calculate our new
+		// expanded horizontal FOV
+		parms.fovX = RE_VfovToHfov( parms.fovY, (float)tr.refdef.width /
+				tr.refdef.height );
+	}
 
 	parms.stereoFrame = tr.refdef.stereoFrame;
 


### PR DESCRIPTION
I noticed that switching to the new engine broke my zoom sensitivity config that uses the tricks described [here](http://openarena.wikia.com/wiki/Configuration_examples/Scale_mouse_sensitivity_with_zoom)

After some investigation I found that the problem was the widescreen support code that calculates new FOV values. I don't know exactly how the previous formula calculated the new FOV values. But I found that it does work for 90 degree FOV, but gives slightly incorrect result for other FOV values.

Hor+ is the formula most commonly used in games. In that formula the vertical
FOV stays the same as if you where playing on 4:3 monitor while the horizontal FOV is expanded to fit the screen. Switching to this formula makes the FOV values consistent with that is used in
most other games.

Fixing this is especially important for [this](https://github.com/OpenArena/gamecode/pull/19) change in the gamecode to work correctly.

I also found the new FOV calculation code to be more readable which is a plus.