### PR TITLE
Fix crashes when compiled with ASan

### DIFF
--- a/Makefile.local.asan
+++ b/Makefile.local.asan
@@ -1,0 +1,7 @@
+# Compiles with ASan (https://github.com/google/sanitizers/wiki/AddressSanitizer)
+# How to use:
+# cp Makefile.local.asan Makefile.local && make
+CC=clang
+CFLAGS+=-fsanitize=address
+CFLAGS+=-g
+CFLAGS+=-fsanitize-recover=address

--- a/asan_ignore.txt
+++ b/asan_ignore.txt
@@ -1,0 +1,1 @@
+fun:VM_Call

--- a/code/client/cl_cgame.c
+++ b/code/client/cl_cgame.c
@@ -618,7 +618,9 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 		Com_Memcpy( VMA(1), VMA(2), args[3] );
 		return 0;
 	case CG_STRNCPY:
-		strncpy( VMA(1), VMA(2), args[3] );
+		if (VMA(1) != VMA(2)) {
+			strncpy( VMA(1), VMA(2), args[3] );
+		}
 		return args[1];
 	case CG_SIN:
 		return FloatAsInt( sin( VMF(1) ) );


### PR DESCRIPTION
This fixes https://github.com/OpenArena/engine/issues/54.

Compiling with ASan makes it easier to find memory errors. Previously the game would compile with ASan but immediately crash if run.