### PR TITLE
MCST Elbrus CPU support

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Makefile.local:
   USE_CURL_DLOPEN    - link with libcurl at runtime
   USE_CODEC_VORBIS   - enable Ogg Vorbis support
   USE_CODEC_OPUS     - enable Ogg Opus support
+  USE_CODEC_XMP      - enable libxmp support for Module player
   USE_MUMBLE         - enable Mumble support
   USE_VOIP           - enable built-in VoIP support
   USE_INTERNAL_SPEEX - build internal speex library instead of dynamically

--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -213,6 +213,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define ARCH_STRING "mips"
 #elif defined __sh__
 #define ARCH_STRING "sh"
+#elif defined __e2k__
+#define ARCH_STRING "e2k"
 #endif
 
 #if __FLOAT_WORD_ORDER == __BIG_ENDIAN


### PR DESCRIPTION
Added initial support for MCST Elbrus CPU which has e2k architecture. This is VLIW/EPIC architecture like Intel Itanium CPU.
The following file have been modified for e2k architecture support:
- \code\qcommon\q_platform.h
Also Readme description updated for USE_CODEC_XMP variable.