### PR TITLE
add aarch64 as platform

### DIFF
--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -205,6 +205,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define ARCH_STRING "sparc"
 #elif defined __arm__
 #define ARCH_STRING "arm"
+#elif defined __aarch64__
+#define ARCH_STRING "aarch64"
 #elif defined __cris__
 #define ARCH_STRING "cris"
 #elif defined __hppa__


### PR DESCRIPTION
Add aarch64 as a platform (for example a Pinebook Pro)