### PR TITLE
fix server-unique GUID

### DIFF
--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -3642,7 +3642,9 @@ void CL_Init( void ) {
 
 	CL_GenerateQKey();
 	Cvar_Get( "cl_guid", "", CVAR_USERINFO | CVAR_ROM );
-	CL_UpdateGUID( NULL, 0 );
+	if (!cl_guidServerUniq->integer) {
+		CL_UpdateGUID( NULL, 0 );
+	}
 
 	Com_Printf( "----- Client Initialization Complete -----\n" );
 }


### PR DESCRIPTION
Fixes a bug that caused the GUID to be reset to its server-independent
value during CL_Init() even though cl_guidServerUniq is set.