### PR TITLE
Provide a custom strncpy implementation

### DIFF
--- a/code/qcommon/q_shared.c
+++ b/code/qcommon/q_shared.c
@@ -1450,3 +1450,21 @@ char *Com_SkipTokens( char *s, int numTokens, char *sep )
 
 int vresWidth;
 int vresHeight;
+
+// This implementation is taken from:
+// https://android.googlesource.com/platform/bionic/+/ics-mr0/libc/string/strncpy.c
+char *custom_strncpy(char *dst, const char *src, size_t n) {
+	if (n != 0) {
+		char *d = dst;
+		const char *s = src;
+		do {
+			if ((*d++ = *s++) == 0) {
+				/* NUL pad the remaining n-1 bytes */
+				while (--n != 0)
+					*d++ = 0;
+				break;
+			}
+		} while (--n != 0);
+	}
+	return (dst);
+}

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -1422,4 +1422,18 @@ extern int vresHeight;
 #define LERP( a, b, w ) ( ( a ) * ( 1.0f - ( w ) ) + ( b ) * ( w ) )
 #define LUMA( red, green, blue ) ( 0.296875f * ( red ) + 0.5859375f * ( green ) + 0.109375f * ( blue ) )
 
+#ifdef strncpy
+#undef strncpy
+#endif
+
+// The C89 standard (and later ones), when defining strncpy, states that "If
+// copying takes place between objects that overlap, the behavior is
+// undefined.". Newer implementation of strncpy provided by clang seems to
+// actually enforce that the arrays do not overlap. As the code in this project
+// seems to call strncpy with overlapping character arrays, let's provide an
+// implementation that's fine with that.
+char *custom_strncpy(char *dst, const char *src, size_t n);
+
+#define strncpy custom_strncpy
+
 #endif	// __Q_SHARED_H


### PR DESCRIPTION
...to work-around strncpy calls that invoke undefined behavior and
actually crash on some standard-compliant C standard library
implementations (at least on newer macOS/clang configrations).