### PR TITLE
Update README to use https protocol instead of the git protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ the build dependencies for the "ioquake3" package.
 ```sh
 $ sudo aptitude build-dep ioquake3
 $ sudo apt-get install libsdl1.2-dev libxmp-dev
-$ git clone git://github.com/OpenArena/engine.git
+$ git clone https://github.com/OpenArena/engine.git
 $ cd engine
 $ make
 ```
@@ -30,11 +30,11 @@ same directory to run it.
 
 ```sh
 # Get this project or sign up on github and fork it
-$ git clone git://github.com/OpenArena/engine.git
+$ git clone https://github.com/OpenArena/engine.git
 $ cd engine
 
 # Create a reference to the upstream project
-$ git remote add upstream git://github.com/ioquake/ioq3.git
+$ git remote add upstream https://github.com/ioquake/ioq3.git
 
 # View changes in this project compared to ioquake3
 $ git fetch upstream


### PR DESCRIPTION
Hello,
According to [this](https://github.blog/2021-09-01-improving-git-protocol-security-github/#when-are-these-changes-effective), GitHub doesn't allow unencrypted protocol to clone/push/fetch and explicitly uses HTTPS (or SSH).  This change happened on March 15, 2022, and trying to clone the repo with the `git://` protocol, will result in a timeout.

### Image
![image](https://github.com/OpenArena/engine/assets/71683721/a96827b2-d81d-4b8b-a27e-1c47c6fb3c1e)
