### PR TITLE
Remove hard coded 640x480, use memmove rather than strncpy for CG_STRNCPY

### DIFF
--- a/code/client/cl_cgame.c
+++ b/code/client/cl_cgame.c
@@ -618,7 +618,7 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 		Com_Memcpy( VMA(1), VMA(2), args[3] );
 		return 0;
 	case CG_STRNCPY:
-		strncpy( VMA(1), VMA(2), args[3] );
+		memmove( VMA(1), VMA(2), args[3] );
 		return args[1];
 	case CG_SIN:
 		return FloatAsInt( sin( VMF(1) ) );

--- a/code/sdl/sdl_glimp.c
+++ b/code/sdl/sdl_glimp.c
@@ -630,12 +630,6 @@ static int GLimp_SetMode(int mode, qboolean fullscreen, qboolean noborder)
 	vresWidth = glConfig.vidWidth;
 	vresHeight = glConfig.vidHeight;
 
-
-
-
-	vresWidth = 640;
-	vresHeight = 480;
-
 #if SDL_MAJOR_VERSION != 2
 	screen = vidscreen;
 #endif


### PR DESCRIPTION
Two small fixes for issues found while porting to macOS aarch64, but both affect all platforms.

**Remove stale vresWidth/vresHeight override in GLimp_SetMode**

vresWidth and vresHeight are correctly set to glConfig.vidWidth/glConfig.vidHeight, but then immediately overwritten with hardcoded 640x480 values. This appears to be a debug leftover.

**Use memmove for CG_STRNCPY VM syscall**

The Q3VM cgame module can pass overlapping src and dst pointers to CG_STRNCPY, since both point into the same VM memory buffer. strncpy does not define behaviour for overlapping buffers - on most platforms this happens to work, but modern hardened libc implementations (e.g. macOS on arm64) detect the overlap at runtime and abort the process.