### PR TITLE
Support MacOS aarch64 / M series chips

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,13 @@ ifeq ($(COMPILE_ARCH),axp)
   COMPILE_ARCH=alpha
 endif
 
+ifeq ($(COMPILE_ARCH),arm)
+  COMPILE_ARCH=aarch64
+endif
+ifeq ($(COMPILE_ARCH),arm64)
+  COMPILE_ARCH=aarch64
+endif
+
 ifndef ARCH
 ARCH=$(COMPILE_ARCH)
 endif
@@ -458,7 +465,9 @@ else # ifeq Linux
 #############################################################################
 
 ifeq ($(PLATFORM),darwin)
-  HAVE_VM_COMPILED=true
+  ifneq ($(findstring $(ARCH),x86 x86_64 ppc ppc64),)
+    HAVE_VM_COMPILED=true
+  endif
   LIBS = -framework Cocoa
   CLIENT_LIBS=
   RENDERER_LIBS=
@@ -481,6 +490,9 @@ ifeq ($(PLATFORM),darwin)
   endif
   ifeq ($(ARCH),x86_64)
     OPTIMIZEVM += -arch x86_64 -mfpmath=sse
+  endif
+  ifeq ($(ARCH),aarch64)
+    OPTIMIZEVM += -arch arm64
   endif
 
   # When compiling on OSX for OSX, we're not cross compiling as far as the

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -2773,7 +2773,7 @@ void Com_Init( char *commandLine ) {
 	Sys_Init();
 
 	if( Sys_WritePIDFile( ) ) {
-#ifndef DEDICATED
+#if !defined(DEDICATED) && !defined(MACOS_X)
 		const char *message = "The last time " CLIENT_WINDOW_TITLE " ran, "
 			"it didn't exit properly. This may be due to inappropriate video "
 			"settings. Would you like to start with \"safe\" video settings?";

--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -161,6 +161,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define idx64 1
 #define ARCH_STRING "x86_64"
 #define Q3_LITTLE_ENDIAN
+#elif defined __aarch64__
+#define ARCH_STRING "aarch64"
+#define Q3_LITTLE_ENDIAN
+#elif defined __arm__
+#define ARCH_STRING "arm"
+#define Q3_LITTLE_ENDIAN
 #endif
 
 #define DLL_EXT ".dylib"


### PR DESCRIPTION
Follow up to https://github.com/OpenArena/engine/pull/104

Adds build and runtime support for macOS on Apple Silicon (aarch64).

**Build support**

- Add __aarch64__ and __arm__ to the macOS architecture detection block in q_platform.h. The existing aarch64 support (added in #64) only covered the Linux block.
- Normalize arm/arm64 → aarch64 in the Makefile, since uname -p returns arm on Apple Silicon Macs.
- Only enable HAVE_VM_COMPILED on architectures that have a bytecode compiler (x86, x86_64, ppc, ppc64). There is no JIT for aarch64, so it falls back to the interpreter.
- Add -arch arm64 to OPTIMIZEVM for the darwin/aarch64 case.

**Skip stale PID dialog on macOS**

On macOS the abnormal exit dialog uses NSAlert, which can block indefinitely when called before the window server connection is fully established - leaving the process hung with no visible UI. This is particularly easy to trigger when running from the command line, since any prior crash or kill leaves a stale PID file. The dialog is skipped on macOS with #if !defined(MACOS_X) while preserving it on Linux and Windows.