### PR TITLE
Remove hardcoded vres and fix CG_STRNCPY.

### DIFF
--- a/code/client/cl_cgame.c
+++ b/code/client/cl_cgame.c
@@ -618,7 +618,7 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 		Com_Memcpy( VMA(1), VMA(2), args[3] );
 		return 0;
 	case CG_STRNCPY:
-		strncpy( VMA(1), VMA(2), args[3] );
+		Q_strncpy( VMA(1), VMA(2), args[3] );
 		return args[1];
 	case CG_SIN:
 		return FloatAsInt( sin( VMF(1) ) );

--- a/code/qcommon/q_shared.c
+++ b/code/qcommon/q_shared.c
@@ -790,6 +790,25 @@ int Q_vsnprintf(char *str, size_t size, const char *format, va_list ap)
 #endif
 
 /*
+ Copied from code/game/bg_lib.c
+ It is here to avoid undifined behavior when source and destination overlap.
+ This is used quite a lot in the code.
+ */
+char *Q_strncpy(char *strDest, const char *strSource, size_t count) {
+	char *s;
+
+	s = strDest;
+	while (*strSource && count) {
+		*s++ = *strSource++;
+		count--;
+	}
+	while (count--) {
+		*s++ = 0;
+	}
+	return strDest;
+}
+
+/*
 =============
 Q_strncpyz
  
@@ -807,7 +826,7 @@ void Q_strncpyz( char *dest, const char *src, int destsize ) {
 		Com_Error(ERR_FATAL,"Q_strncpyz: destsize < 1" ); 
 	}
 
-	strncpy( dest, src, destsize-1 );
+	Q_strncpy( dest, src, destsize-1 );
   dest[destsize-1] = 0;
 }
                  

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -811,6 +811,7 @@ char	*Q_strupr( char *s1 );
 const char	*Q_stristr( const char *s, const char *find);
 
 // buffer size safe library replacements
+char	*Q_strncpy(char *strDest, const char *strSource, size_t count);
 void	Q_strncpyz( char *dest, const char *src, int destsize );
 void	Q_strcat( char *dest, int size, const char *src );
 

--- a/code/sdl/sdl_glimp.c
+++ b/code/sdl/sdl_glimp.c
@@ -630,12 +630,6 @@ static int GLimp_SetMode(int mode, qboolean fullscreen, qboolean noborder)
 	vresWidth = glConfig.vidWidth;
 	vresHeight = glConfig.vidHeight;
 
-
-
-
-	vresWidth = 640;
-	vresHeight = 480;
-
 #if SDL_MAJOR_VERSION != 2
 	screen = vidscreen;
 #endif


### PR DESCRIPTION
This is alternative approach compared to PR 104 by jackharrhy

This also makes the engine work with 0.8.8 vm files on my Linux machine.